### PR TITLE
Rewording zip code search

### DIFF
--- a/Pakettikauppa/Logistics/view/frontend/layout/checkout_index_index.xml
+++ b/Pakettikauppa/Logistics/view/frontend/layout/checkout_index_index.xml
@@ -39,7 +39,7 @@
                                                                                     </item>
                                                                                     <item name="provider" xsi:type="string">checkoutProvider</item>
                                                                                     <item name="dataScope" xsi:type="string">pickuppointForm.pickuppoint-zip</item>
-                                                                                    <item name="label" xsi:type="string">Insert Zip Code</item>
+                                                                                    <item name="label" xsi:type="string" translate="true">Search alternative pickup points by Zip Code</item>
                                                                                     <item name="sortOrder" xsi:type="string">1</item>
                                                                                     <!-- <item name="validation" xsi:type="array">
                                                                                         <item name="required-entry" xsi:type="string">true</item>

--- a/Pakettikauppa/Logistics/view/frontend/web/template/pickuppoint-form.html
+++ b/Pakettikauppa/Logistics/view/frontend/web/template/pickuppoint-form.html
@@ -1,7 +1,6 @@
 <div>
     <form id="pickuppoint-form" class="form" data-bind="attr: {'data-hasrequired': $t('* Required Fields')}">
         <fieldset class="fieldset">
-            <legend data-bind="i18n: 'Search pickuppoints'"></legend>
             <!-- ko foreach: getRegion('pickuppoint-form-fields') -->
             <!-- ko template: getTemplate() --><!-- /ko -->
             <!--/ko-->


### PR DESCRIPTION
- Removes "Search pickuppoints" text
- Renames "Insert Zip Code" to "Search alternative pickup points by Zip Code"

Makes new string translatable, unlike the previous one which could not be translated.

Example in Finnish

![Screenshot from 2019-06-18 05-30-33](https://user-images.githubusercontent.com/12877644/59649136-37408380-918a-11e9-98a0-588b05111dd0.png)
