### PR TITLE
Parse dashes from carrier code names

### DIFF
--- a/Pakettikauppa/Logistics/Helper/Data.php
+++ b/Pakettikauppa/Logistics/Helper/Data.php
@@ -14,7 +14,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getCarrierCode($carrier, $name)
     {
         $carrier = preg_replace('/[^\00-\255]+/u', '', strtolower(preg_replace('/\s+/', '', $carrier)));
-        $name = preg_replace('/[^\00-\255]+/u', '', strtolower(preg_replace('/\s+/', '', $name)));
+        $name = preg_replace('/[^\00-\255]+/u', '', strtolower(preg_replace('/\s+/', '', preg_replace('/\-/', '', $name))));
         $code = $carrier . '_' . $name;
         if ($code == 'posti_palautus') {
             return false;

--- a/Pakettikauppa/Logistics/etc/adminhtml/system.xml
+++ b/Pakettikauppa/Logistics/etc/adminhtml/system.xml
@@ -108,7 +108,7 @@
                     <validate>validate-number validate-zero-or-greater</validate>
                 </field>
             </group>
-            <group id="posti_express" translate="label" type="text" sortOrder="191" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="posti_expresspaketti" translate="label" type="text" sortOrder="191" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Posti - Express</label>
                 <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Enabled</label>


### PR DESCRIPTION
...as Magento2 does not allow dashes in config keys.

This fixes a bug where Posti Express delivery method was not visible.