### PR TITLE
Specify SCOPE_STORE when loading configuration values

### DIFF
--- a/Pakettikauppa/Logistics/Helper/Api.php
+++ b/Pakettikauppa/Logistics/Helper/Api.php
@@ -55,7 +55,7 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
         $this->logger = $logger;
         $this->directory_list = $directory_list;
         $this->scopeConfig = $scopeConfig;
-        $this->active = $this->scopeConfig->getValue('pakettikauppa_config/store/active');
+        $this->active = $this->scopeConfig->getValue('pakettikauppa_config/store/active', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
         if ($this->active == 1) {
             $this->development = true;
         } else {
@@ -64,8 +64,8 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
         if ($this->development) {
             $this->client = new Client(['test_mode' => true]);
         } else {
-            $this->key = $this->scopeConfig->getValue('pakettikauppa_config/api/api_key');
-            $this->secret = $this->scopeConfig->getValue('pakettikauppa_config/api/api_secret_key');
+            $this->key = $this->scopeConfig->getValue('pakettikauppa_config/api/api_key', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+            $this->secret = $this->scopeConfig->getValue('pakettikauppa_config/api/api_secret_key', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
             if (isset($this->key) && isset($this->secret)) {
                 $params['api_key'] = $this->key;
                 $params['secret'] = $this->secret;
@@ -80,7 +80,7 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $allowed = [];
         foreach ($this->pickup_methods as $method) {
-            if ($this->scopeConfig->getValue('carriers/' . $method['id'] . '_pickuppoint/active') == 1) {
+            if ($this->scopeConfig->getValue('carriers/' . $method['id'] . '_pickuppoint/active', \Magento\Store\Model\ScopeInterface::SCOPE_STORE) == 1) {
                 $allowed[] = $method['name'];
             }
         }
@@ -133,11 +133,11 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
         $sender = new Sender();
         $store = $order->getStoreId();
 
-        $_sender_name = $this->scopeConfig->getValue('pakettikauppa_config/store/name');
-        $_sender_address = $this->scopeConfig->getValue('pakettikauppa_config/store/address');
-        $_sender_city = $this->scopeConfig->getValue('pakettikauppa_config/store/city');
-        $_sender_postcode = $this->scopeConfig->getValue('pakettikauppa_config/store/postcode');
-        $_sender_country = $this->scopeConfig->getValue('pakettikauppa_config/store/country');
+        $_sender_name = $this->scopeConfig->getValue('pakettikauppa_config/store/name', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        $_sender_address = $this->scopeConfig->getValue('pakettikauppa_config/store/address', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        $_sender_city = $this->scopeConfig->getValue('pakettikauppa_config/store/city', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        $_sender_postcode = $this->scopeConfig->getValue('pakettikauppa_config/store/postcode', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        $_sender_country = $this->scopeConfig->getValue('pakettikauppa_config/store/country', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
         $sender->setName1($_sender_name);
         $sender->setAddr1($_sender_address);
         $sender->setPostcode($_sender_postcode);

--- a/Pakettikauppa/Logistics/Model/Carrier/Homedelivery.php
+++ b/Pakettikauppa/Logistics/Model/Carrier/Homedelivery.php
@@ -59,7 +59,7 @@ class Homedelivery extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
             foreach ($homedelivery as $hd) {
                 $carrier_code = $this->dataHelper->getCarrierCode($hd->service_provider, $hd->name);
                 if ($carrier_code) {
-                    $enabled = $this->scopeConfig->getValue('carriers/' . $carrier_code . '/active');
+                    $enabled = $this->scopeConfig->getValue('carriers/' . $carrier_code . '/active', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
                 } else {
                     $enabled = 0;
                 }
@@ -71,8 +71,8 @@ class Homedelivery extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
                     if (property_exists($hd, 'icon')) {
                         $data[$hd->service_provider] = '<img src="' . $hd->icon . '" alt="' . $hd->service_provider . '"/>';
                     }
-                    $db_price =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/price');
-                    $db_title =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/title');
+                    $db_price =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/price', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+                    $db_title =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/title', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
                     $conf_price = $this->getConfigData('price');
                     $conf_title = $this->getConfigData('title');
                     if ($db_price == '') {
@@ -87,8 +87,8 @@ class Homedelivery extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
                     }
 
                     // DISCOUNT PRICE
-                    $minimum =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/cart_price');
-                    $new_price =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/new_price');
+                    $minimum =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/cart_price', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+                    $new_price =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/new_price', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
                     if ($cart_value && $minimum && $cart_value >= $minimum) {
                         $price = $new_price;
                     }

--- a/Pakettikauppa/Logistics/Model/Carrier/Pickuppoint.php
+++ b/Pakettikauppa/Logistics/Model/Carrier/Pickuppoint.php
@@ -63,7 +63,7 @@ class Pickuppoint extends \Magento\Shipping\Model\Carrier\AbstractCarrier implem
                 foreach ($pickuppoints as $pp) {
                     $carrier_code = $this->dataHelper->getCarrierCode($pp->provider, 'pickuppoint');
                     if ($carrier_code) {
-                        $enabled = $this->scopeConfig->getValue('carriers/' . $carrier_code . '/active');
+                        $enabled = $this->scopeConfig->getValue('carriers/' . $carrier_code . '/active', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
                     } else {
                         $enabled = 0;
                     }
@@ -75,8 +75,8 @@ class Pickuppoint extends \Magento\Shipping\Model\Carrier\AbstractCarrier implem
                         if (property_exists($pp, 'provider_logo')) {
                             $data[$pp->provider . " - " . $pp->name . ": " . $pp->street_address . ", " . $pp->postcode . ", " . $pp->city] = '<img src="' . $pp->provider_logo . '" alt="' . $pp->provider . '"/>';
                         }
-                        $db_price =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/price');
-                        $db_title =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/title');
+                        $db_price =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/price', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+                        $db_title =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/title', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
                         $conf_price = $this->getConfigData('price');
                         $conf_title = $this->getConfigData('title');
                         if ($db_price == '') {
@@ -91,8 +91,8 @@ class Pickuppoint extends \Magento\Shipping\Model\Carrier\AbstractCarrier implem
                         }
 
                         // // DISCOUNT PRICE
-                        $minimum =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/cart_price');
-                        $new_price =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/new_price');
+                        $minimum =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/cart_price', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+                        $new_price =  $this->scopeConfig->getValue('carriers/' . $carrier_code . '/new_price', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
                         if ($cart_value && $minimum && $cart_value >= $minimum) {
                             $price = $new_price;
                         }


### PR DESCRIPTION
This PR fixes an issue where store owner could not specify shipping methods at store-level scope.