### PR TITLE
Copy shipping form postcode into pickup zip field

### DIFF
--- a/Pakettikauppa/Logistics/view/frontend/web/js/view/pickuppoint-form.js
+++ b/Pakettikauppa/Logistics/view/frontend/web/js/view/pickuppoint-form.js
@@ -18,6 +18,22 @@ define([
                   }
                 }
             });
+            // When modifying shipping form postcode, automatically copy it to
+            // pickuppoint-zip for user-friendliness
+            jQuery(document).on('change', function(e) {
+                var pickupZip = jQuery('#pickuppoint-form input[name="pickuppoint-zip"]');
+                if (e.target.id === pickupZip.attr('id')) {
+                    return false;
+                }
+                var postcode = jQuery('input[name="postcode"]').val();
+                if(postcode.length>0
+                   && jQuery('input[name="pickuppoint-zip"]').val().length == 0
+                   && !jQuery('#pickuppoint-form input.input-text').is(':focus'))
+                {
+                    pickupZip.val(postcode).change();
+                    jQuery("#pktkpgetpickups").click();
+                }
+            });
             // component initialization logic
             return this;
         },


### PR DESCRIPTION
Super user friendly!

I thought this feature already existed, but perhaps I was dreaming? Or maybe some
other commit removed it.