### PR TITLE
Support orders via admin area

### DIFF
--- a/Pakettikauppa/Logistics/Helper/Data.php
+++ b/Pakettikauppa/Logistics/Helper/Data.php
@@ -27,19 +27,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function getZip()
     {
-        $zip_pickup = $this->cart->getQuote()->getData('pickuppoint_zip');
-        $zip_shipping = $this->cart->getQuote()->getShippingAddress()->getPostcode();
-        $zip_backend = $this->backendQuoteSession->getQuote()->getShippingAddress()->getPostcode();
+        $zip = false;
 
-        if ($zip_pickup) {
-            return $zip_pickup;
-        } elseif ($zip_shipping) {
-            return $zip_shipping;
-        } elseif ($zip_backend) {
-            return $zip_backend;
-        } else {
-            return false;
+        if ($zip = $this->cart->getQuote()->getData('pickuppoint_zip')) {
+            return $zip;
+        } elseif ($zip = $this->cart->getQuote()->getShippingAddress()->getPostcode()) {
+            return $zip;
+        } elseif ($zip = $this->backendQuoteSession->getQuote()->getShippingAddress()->getPostcode()) {
+            return $zip;
         }
+        return $zip;
     }
     public function getPickupPointServiceCode($data, $provider)
     {

--- a/Pakettikauppa/Logistics/Helper/Data.php
+++ b/Pakettikauppa/Logistics/Helper/Data.php
@@ -6,9 +6,11 @@ use Magento\Checkout\Model\Cart;
 class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
     public function __construct(
-        Cart $cart
+        Cart $cart,
+        \Magento\Backend\Model\Session\Quote $backendQuoteSession
     ) {
         $this->cart = $cart;
+        $this->backendQuoteSession = $backendQuoteSession;
     }
 
     public function getCarrierCode($carrier, $name)
@@ -27,10 +29,14 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $zip_pickup = $this->cart->getQuote()->getData('pickuppoint_zip');
         $zip_shipping = $this->cart->getQuote()->getShippingAddress()->getPostcode();
+        $zip_backend = $this->backendQuoteSession->getQuote()->getShippingAddress()->getPostcode();
+
         if ($zip_pickup) {
             return $zip_pickup;
         } elseif ($zip_shipping) {
             return $zip_shipping;
+        } elseif ($zip_backend) {
+            return $zip_backend;
         } else {
             return false;
         }

--- a/Pakettikauppa/Logistics/Observer/OrderObserver.php
+++ b/Pakettikauppa/Logistics/Observer/OrderObserver.php
@@ -23,12 +23,14 @@ class OrderObserver implements ObserverInterface
         OrderInterface $order,
         LoggerInterface $logger,
         Cart $cart,
+        \Magento\Backend\Model\Session\Quote $backendQuoteSession,
         Api $apiHelper,
         Data $dataHelper
     ) {
         $this->_order = $order;
         $this->logger = $logger;
         $this->cart = $cart;
+        $this->backendQuoteSession = $backendQuoteSession;
         $this->apiHelper = $apiHelper;
         $this->dataHelper = $dataHelper;
     }
@@ -38,6 +40,11 @@ class OrderObserver implements ObserverInterface
             $quote = $this->cart->getQuote();
             $order = $observer->getOrder();
             $shipping_method_code = $quote->getShippingAddress()->getShippingMethod();
+
+            if (!$shipping_method_code) {
+                // For orders created via admin area
+                $shipping_method_code = $this->backendQuoteSession->getQuote()->getShippingAddress()->getShippingMethod();
+            }
 
             if ($this->dataHelper->isPakettikauppa($shipping_method_code)) {
                 $method = $this->dataHelper->getMethod($shipping_method_code);

--- a/Pakettikauppa/Logistics/view/adminhtml/layout/sales_order_create_load_block_shipping_method.xml
+++ b/Pakettikauppa/Logistics/view/adminhtml/layout/sales_order_create_load_block_shipping_method.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method" template="Magento_Sales::order/create/abstract.phtml" name="shipping_method">
+                <block class="Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method\Form" template="Pakettikauppa_Logistics::order/create/shipping/method/form.phtml" name="order.create.shipping.method.form.custom" as="form"/>
+            </block>
+        </referenceContainer>
+    </body>
+</page>

--- a/Pakettikauppa/Logistics/view/adminhtml/templates/order/create/shipping/method/form.phtml
+++ b/Pakettikauppa/Logistics/view/adminhtml/templates/order/create/shipping/method/form.phtml
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+// @codingStandardsIgnoreFile
+
+?>
+<?php /** @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method\Form */ ?>
+<?php $_shippingRateGroups = $block->getShippingRates(); ?>
+<?php if ($_shippingRateGroups): ?>
+    <div id="order-shipping-method-choose" class="control" style="display:none">
+        <dl class="admin__order-shipment-methods">
+        <?php foreach ($_shippingRateGroups as $code => $_rates): ?>
+            <dt class="admin__order-shipment-methods-title"><?= $block->escapeHtml($block->getCarrierName($code)) ?></dt>
+            <dd class="admin__order-shipment-methods-options">
+                <ul class="admin__order-shipment-methods-options-list">
+                <?php foreach ($_rates as $_rate): ?>
+                    <?php $_radioProperty = 'name="order[shipping_method]" type="radio" onclick="order.setShippingMethod(this.value)"' ?>
+                    <?php $_code = $_rate->getCode() ?>
+                    <li class="admin__field-option">
+                       <?php if ($_rate->getErrorMessage()): ?>
+                           <div class="messages">
+                               <div class="message message-error error">
+                                   <div><?= $block->escapeHtml($_rate->getErrorMessage()) ?></div>
+                               </div>
+                           </div>
+                       <?php else: ?>
+                            <?php $_checked = $block->isMethodActive($_code) ? 'checked="checked"' : '' ?>
+                            <input <?= /* @escapeNotVerified */ $_radioProperty ?> value="<?= /* @escapeNotVerified */ $_code ?>"
+                                                                 id="s_method_<?= /* @escapeNotVerified */ $_code ?>" <?= /* @escapeNotVerified */ $_checked ?>
+                                                                 class="admin__control-radio required-entry"/>
+                            <label class="admin__field-label" for="s_method_<?= /* @escapeNotVerified */ $_code ?>">
+                                <?= $block->escapeHtml($_rate->getMethodTitle() ? $_rate->getMethodTitle() : $_rate->getMethodDescription()) ?> -
+                                <strong>
+                                    <?php $_excl = $block->getShippingPrice($_rate->getPrice(), $this->helper('Magento\Tax\Helper\Data')->displayShippingPriceIncludingTax()); ?>
+                                    <?php $_incl = $block->getShippingPrice($_rate->getPrice(), true); ?>
+
+                                    <?= /* @escapeNotVerified */ $_excl ?>
+                                    <?php if ($this->helper('Magento\Tax\Helper\Data')->displayShippingBothPrices() && $_incl != $_excl): ?>
+                                        (<?= /* @escapeNotVerified */ __('Incl. Tax') ?> <?= /* @escapeNotVerified */ $_incl ?>)
+                                    <?php endif; ?>
+                                </strong>
+                            </label>
+                       <?php endif ?>
+                    </li>
+                <?php endforeach; ?>
+                </ul>
+            </dd>
+        <?php endforeach; ?>
+        </dl>
+    </div>
+    <?php if ($_rate = $block->getActiveMethodRate()): ?>
+        <div id="order-shipping-method-info" class="order-shipping-method-info">
+            <dl class="admin__order-shipment-methods">
+                <dt class="admin__order-shipment-methods-title">
+                    <?= $block->escapeHtml($block->getCarrierName($_rate->getCarrier())) ?>
+                </dt>
+                <dd class="admin__order-shipment-methods-options">
+                    <?= $block->escapeHtml($_rate->getMethodTitle() ? $_rate->getMethodTitle() : $_rate->getMethodDescription()) ?> -
+                    <strong>
+                        <?php $_excl = $block->getShippingPrice($_rate->getPrice(), $this->helper('Magento\Tax\Helper\Data')->displayShippingPriceIncludingTax()); ?>
+                        <?php $_incl = $block->getShippingPrice($_rate->getPrice(), true); ?>
+
+                        <?= /* @escapeNotVerified */ $_excl ?>
+                        <?php if ($this->helper('Magento\Tax\Helper\Data')->displayShippingBothPrices() && $_incl != $_excl): ?>
+                            (<?= /* @escapeNotVerified */ __('Incl. Tax') ?> <?= /* @escapeNotVerified */ $_incl ?>)
+                        <?php endif; ?>
+                    </strong>
+                </dd>
+            </dl>
+            <a href="#"
+               onclick="$('order-shipping-method-info').hide();$('order-shipping-method-choose').show();return false"
+               class="action-default">
+                <span><?= /* @escapeNotVerified */ __('Click to change shipping method') ?></span>
+            </a>
+        </div>
+    <?php else: ?>
+        <script>
+require(['prototype'], function(){
+    $('order-shipping-method-choose').show();
+});
+</script>
+    <?php endif; ?>
+<?php elseif ($block->getIsRateRequest()): ?>
+    <div class="order-shipping-method-summary">
+        <strong class="order-shipping-method-not-available"><?= /* @escapeNotVerified */ __('Sorry, no quotes are available for this order.') ?></strong>
+    </div>
+<?php else: ?>
+    <div id="order-shipping-method-summary" class="order-shipping-method-summary">
+        <a href="#" onclick="order.loadShippingRates();return false" class="action-default">
+            <span><?= /* @escapeNotVerified */ __('Get shipping methods and rates') ?></span>
+        </a>
+        <input type="hidden" name="order[has_shipping]" value="" class="required-entry" />
+    </div>
+<?php endif; ?>
+<div style="display: none;" id="shipping-method-overlay" class="order-methods-overlay">
+    <span><?= /* @escapeNotVerified */ __('You don\'t need to select a shipping method.') ?></span>
+</div>
+<script>
+    require(["Magento_Sales/order/create/form"], function(){
+        order.overlay('shipping-method-overlay', <?php if ($block->getQuote()->isVirtual()): ?>false<?php else: ?>true<?php endif; ?>);
+        order.overlay('address-shipping-overlay', <?php if ($block->getQuote()->isVirtual()): ?>false<?php else: ?>true<?php endif; ?>);
+        order.isOnlyVirtualProduct = <?= /* @noEscape */ $block->getQuote()->isVirtual() ? 'true' : 'false'; ?>;
+    });
+</script>

--- a/Pakettikauppa/Logistics/view/adminhtml/templates/order/create/shipping/method/form.phtml
+++ b/Pakettikauppa/Logistics/view/adminhtml/templates/order/create/shipping/method/form.phtml
@@ -33,6 +33,7 @@
                                                                  class="admin__control-radio required-entry"/>
                             <label class="admin__field-label" for="s_method_<?= /* @escapeNotVerified */ $_code ?>">
                                 <?= $block->escapeHtml($_rate->getMethodTitle() ? $_rate->getMethodTitle() : $_rate->getMethodDescription()) ?> -
+                                <?= $block->escapeHtml($_rate->getCarrierTitle()) ?> -
                                 <strong>
                                     <?php $_excl = $block->getShippingPrice($_rate->getPrice(), $this->helper('Magento\Tax\Helper\Data')->displayShippingPriceIncludingTax()); ?>
                                     <?php $_incl = $block->getShippingPrice($_rate->getPrice(), true); ?>
@@ -59,6 +60,7 @@
                 </dt>
                 <dd class="admin__order-shipment-methods-options">
                     <?= $block->escapeHtml($_rate->getMethodTitle() ? $_rate->getMethodTitle() : $_rate->getMethodDescription()) ?> -
+                    <?= $block->escapeHtml($_rate->getCarrierTitle()) ?> -
                     <strong>
                         <?php $_excl = $block->getShippingPrice($_rate->getPrice(), $this->helper('Magento\Tax\Helper\Data')->displayShippingPriceIncludingTax()); ?>
                         <?php $_incl = $block->getShippingPrice($_rate->getPrice(), true); ?>


### PR DESCRIPTION
It is currently impossible to place orders via admin area / backend with the shipping methods provided in this module. The way admin area orders work is a bit different from customer side and it seems this plugin was never designed to support admin area orders.

For example, reading the shipping address is done via Magento\Backend\Model\Session\Quote instead of Magento\Checkout\Model\Cart that is used in this module.

Also, the module has problems displaying pickup points detailed description in adminhtml. Right now we can see just "Pickuppoint" and not e.g. "Pickuppoint - Posti - Joensuu - Kauppakatu S-Market". It's impossible to select your desired pickup location from a list of pickup points labelled "Pickuppoint" :)

We have to be able to support this functionality because we will integrate it into our reclamation process and that is handled via the admin area.