### PR TITLE
Display shipment exceptions in admin area

### DIFF
--- a/Pakettikauppa/Logistics/Helper/Api.php
+++ b/Pakettikauppa/Logistics/Helper/Api.php
@@ -192,6 +192,9 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
             }
         } catch (\Exception $ex) {
             $this->logger->critical('Shipment not created, please double check your store settings on STORE view level. Additional message: ' . $ex->getMessage());
+            throw new \Magento\Framework\Exception\LocalizedException(
+                __($ex->getMessage())
+            );
         }
     }
 


### PR DESCRIPTION
When an exception occurs during createShipment(), Magento will display
mysterious "Cannot save track: Number can not be empty" error message to
admins.

This patch rethrows Pakettikauppa's error so that it's easier for shop owners
to figure out the issue and save their developer's precious work time.

before patch:
![pakettikauppa_exception1](https://user-images.githubusercontent.com/12877644/65070625-a9954f80-d995-11e9-9677-6e3d405d1847.png)

after patch:
![pakettikauppa_exception2](https://user-images.githubusercontent.com/12877644/65070668-bc0f8900-d995-11e9-9d4d-4287cee4d94f.png)
