### PR TITLE
Hide shipping methods for non-supported countries 

### DIFF
--- a/Pakettikauppa/Logistics/Helper/Data.php
+++ b/Pakettikauppa/Logistics/Helper/Data.php
@@ -38,6 +38,18 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         }
         return $zip;
     }
+
+    public function getCountry() {
+        $country = false;
+
+        if ($country = $this->cart->getQuote()->getShippingAddress()->getCountryId()) {
+            return $country;
+        } elseif ($country = $this->backendQuoteSession->getQuote()->getShippingAddress()->getCountryId()) {
+            return $country;
+        }
+        return $country;
+    }
+
     public function getPickupPointServiceCode($data, $provider)
     {
         $result = 0;

--- a/Pakettikauppa/Logistics/Model/Carrier/Homedelivery.php
+++ b/Pakettikauppa/Logistics/Model/Carrier/Homedelivery.php
@@ -64,6 +64,10 @@ class Homedelivery extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
                     $enabled = 0;
                 }
                 if ($enabled == 1) {
+                    // Check if this shipping method supports the country
+                    if (!in_array($this->dataHelper->getCountry(), $hd->supported_countries, true)) {
+                        continue;
+                    }
                     $method = $this->rateMethodFactory->create();
                     $method->setCarrier('pktkphomedelivery');
                     $method->setCarrierTitle($hd->service_provider);

--- a/Pakettikauppa/Logistics/view/frontend/requirejs-config.js
+++ b/Pakettikauppa/Logistics/view/frontend/requirejs-config.js
@@ -4,5 +4,12 @@ var config = {
       "Magento_Checkout/template/shipping.html":
           "Pakettikauppa_Logistics/template/shipping.html"
     }
+  },
+  config: {
+    mixins: {
+      'Magento_Checkout/js/model/shipping-rates-validation-rules': {
+        'Pakettikauppa_Logistics/js/model/shipping-rates-validation-rules-mixin': true
+      }
+    }
   }
 };

--- a/Pakettikauppa/Logistics/view/frontend/web/js/model/shipping-rates-validation-rules-mixin.js
+++ b/Pakettikauppa/Logistics/view/frontend/web/js/model/shipping-rates-validation-rules-mixin.js
@@ -1,0 +1,25 @@
+define(['jquery'], function ($) {
+    'use strict';
+
+    return function (targetFunction) {
+        targetFunction.getObservableFields = function () {
+            var self = this,
+                observableFields = [];
+
+            $.each(self.getRules(), function (carrier, fields) {
+                $.each(fields, function (field) {
+                    if (observableFields.indexOf(field) === -1) {
+                        observableFields.push(field);
+                    }
+                });
+            });
+
+            observableFields.push('country_id'); // Load shipping method on Country chnage
+            observableFields.push('postcode'); // Load shipping method on Postcode chnage
+
+            return observableFields;
+        }
+
+        return targetFunction;
+    };
+});

--- a/Pakettikauppa/Logistics/view/frontend/web/js/view/pickuppoint-form.js
+++ b/Pakettikauppa/Logistics/view/frontend/web/js/view/pickuppoint-form.js
@@ -20,7 +20,7 @@ define([
             });
             // When modifying shipping form postcode, automatically copy it to
             // pickuppoint-zip for user-friendliness
-            jQuery(document).on('change', function(e) {
+            jQuery('input[name="postcode"]').on('change', function(e) {
                 var pickupZip = jQuery('#pickuppoint-form input[name="pickuppoint-zip"]');
                 if (e.target.id === pickupZip.attr('id')) {
                     return false;


### PR DESCRIPTION
It is currently possible to select a home delivery shipping method for an address outside of the list of supported countries. This should not happen.

Pakettikauppa API provides a property "supported_countries".

Check country of customer's shipping address and hide methods that do not apply for their country.