### PR TITLE
Fix Minimum cart price for discount shipping excl tax

### DIFF
--- a/Pakettikauppa/Logistics/Model/Carrier/Homedelivery.php
+++ b/Pakettikauppa/Logistics/Model/Carrier/Homedelivery.php
@@ -52,10 +52,8 @@ class Homedelivery extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
         }
         $homedelivery = $this->apiHelper->getHomeDelivery();
         if (count($homedelivery)>0) {
-            $cart_value = 0;
-            foreach ($this->session->getQuote()->getAllItems() as $item) {
-                $cart_value = $cart_value + ($item->getPrice() * $item->getQty());
-            }
+            $cart_value = $request->getPackageValueWithDiscount();
+
             foreach ($homedelivery as $hd) {
                 $carrier_code = $this->dataHelper->getCarrierCode($hd->service_provider, $hd->name);
                 if ($carrier_code) {

--- a/Pakettikauppa/Logistics/Model/Carrier/Pickuppoint.php
+++ b/Pakettikauppa/Logistics/Model/Carrier/Pickuppoint.php
@@ -55,10 +55,7 @@ class Pickuppoint extends \Magento\Shipping\Model\Carrier\AbstractCarrier implem
         if ($zip) {
             $pickuppoints = $this->apiHelper->getPickuppoints($zip);
             if (!empty($pickuppoints) && count($pickuppoints) > 0) {
-                $cart_value = 0;
-                foreach ($this->session->getQuote()->getAllItems() as $item) {
-                    $cart_value = $cart_value + ($item->getPrice() * $item->getQty());
-                }
+                $cart_value = $request->getPackageValueWithDiscount();
 
                 foreach ($pickuppoints as $pp) {
                     $carrier_code = $this->dataHelper->getCarrierCode($pp->provider, 'pickuppoint');


### PR DESCRIPTION
Adding "Minimum cart price for discount shipping" to a shipping method was calculated based on total cart value excluding taxes (VAT) and discounts.

This fix will calculate discount shipping based on total cart value after discounts according to standard Magento 2 way of doing it in their free shipping module.