### PR TITLE
Fix SimpleXMLElement inheritance error on PHP 8.1

### DIFF
--- a/Pakettikauppa/Logistics/Helper/pakettikauppa/SimpleXMLElement.php
+++ b/Pakettikauppa/Logistics/Helper/pakettikauppa/SimpleXMLElement.php
@@ -10,7 +10,7 @@ class SimpleXMLElement extends \SimpleXMLElement
    * @param string
    * @param string
    */
-  public function addChild($key, $value = null, $namespace = null)
+  public function addChild($key, $value = null, $namespace = null): ?SimpleXMLElement
   {
     if ( $value != null )
     {


### PR DESCRIPTION
During upgrade the following error occurs:

```
php bin/magento setup:di:compile
Compilation was started.
PHP Fatal error:  During inheritance of SimpleXMLElement: Uncaught Exception: Deprecated Functionality: Return type of Pakettikauppa\SimpleXMLElement::addChild($key, $value = null, $namespace = null) should either be compatible with SimpleXMLElement::addChild(string $qualifiedName, ?string $value = null, ?string $namespace = null): ?SimpleXMLElement, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /vendor/pakettikauppa/pakettikauppa-magento-2/Pakettikauppa/Logistics/Helper/pakettikauppa/SimpleXMLElement.php on line 13 in /vendor/magento/framework/App/ErrorHandler.php:62
Stack trace:
0 /vendor/pakettikauppa/pakettikauppa-magento-2/Pakettikauppa/Logistics/Helper/Api.php(13): Magento\Framework\App\ErrorHandler->handler()
1 /vendor/pakettikauppa/pakettikauppa-magento-2/Pakettikauppa/Logistics/Helper/Api.php(13): require_once()
...
17 {main} in /vendor/pakettikauppa/pakettikauppa-magento-2/Pakettikauppa/Logistics/Helper/pakettikauppa/SimpleXMLElement.php on line 5
```

This PR adds support for PHP 8.1