### PR TITLE
Fix issue with home delivery methods not showing at checkout

### DIFF
--- a/Pakettikauppa/Logistics/Helper/Api.php
+++ b/Pakettikauppa/Logistics/Helper/Api.php
@@ -106,22 +106,8 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
             return $methods;
         }
 
-        $counter = 0;
         foreach ($methods as $method) {
-            if (count($method->additional_services) > 0) {
-                foreach ($method->additional_services as $service) {
-                    if ($service->service_code == '2106') {
-                        $method->name = null;
-                        $method->shipping_method_code = null;
-                        $method->description = null;
-                        $method->service_provider = null;
-                        $method->additional_services = null;
-                    }
-                }
-            }
-        }
-        foreach ($methods as $method) {
-            if ($method->name != null) {
+            if ($method->name != null && $method->home_delivery == true) {
                 $result[] = $method;
             }
         }

--- a/Pakettikauppa/Logistics/Helper/Data.php
+++ b/Pakettikauppa/Logistics/Helper/Data.php
@@ -2,6 +2,9 @@
 namespace Pakettikauppa\Logistics\Helper;
 
 use Magento\Checkout\Model\Cart;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address\RateRequest;
+use Magento\Quote\Model\Quote\Item;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
@@ -44,6 +47,27 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function validateZip($zip): bool
     {
         return is_string($zip) && strlen($zip) >= static::ZIP_MIN_LENGTH;
+    }
+
+    public function getQuoteSafely($request)
+    {
+        $items = $request->getAllItems();
+        if (empty($items)) {
+            return false;
+        }
+
+        /** @var Item $firstItem */
+        $firstItem = reset($items);
+        if (!$firstItem) {
+            return false;
+        }
+
+        $quote = $firstItem->getQuote();
+        if (!($quote instanceof Quote)) {
+            return false;
+        }
+
+        return $quote;
     }
 
     public function getCountry() {

--- a/Pakettikauppa/Logistics/Helper/Data.php
+++ b/Pakettikauppa/Logistics/Helper/Data.php
@@ -5,6 +5,8 @@ use Magento\Checkout\Model\Cart;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
+    const ZIP_MIN_LENGTH = 5;
+
     public function __construct(
         Cart $cart,
         \Magento\Backend\Model\Session\Quote $backendQuoteSession
@@ -37,6 +39,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             return $zip;
         }
         return $zip;
+    }
+
+    public function validateZip($zip): bool
+    {
+        return is_string($zip) && strlen($zip) >= static::ZIP_MIN_LENGTH;
     }
 
     public function getCountry() {
@@ -82,6 +89,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function getMethod($code)
     {
+        if (empty($code)) return '';
         if (strpos($code, 'pktkppickuppoint') !== false) {
             return 'pktkppickuppoint';
         }
@@ -92,7 +100,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function isPakettikauppa($code)
     {
-        if (strpos($code, 'pktkppickuppoint') !== false || strpos($code, 'pktkphomedelivery') !== false) {
+        if (!empty($code) && (strpos($code, 'pktkppickuppoint') !== false || strpos($code, 'pktkphomedelivery') !== false)) {
             return true;
         } else {
             return false;

--- a/Pakettikauppa/Logistics/Model/Carrier/Homedelivery.php
+++ b/Pakettikauppa/Logistics/Model/Carrier/Homedelivery.php
@@ -63,7 +63,8 @@ class Homedelivery extends \Magento\Shipping\Model\Carrier\AbstractCarrier imple
                 }
                 if ($enabled == 1) {
                     // Check if this shipping method supports the country
-                    if (!in_array($this->dataHelper->getCountry(), $hd->supported_countries, true)) {
+                    $quote = $this->dataHelper->getQuoteSafely($request);
+                    if (!in_array($quote->getShippingAddress()->getCountryId(), $hd->supported_countries, true)) {
                         continue;
                     }
                     $method = $this->rateMethodFactory->create();

--- a/Pakettikauppa/Logistics/Model/Carrier/Pickuppoint.php
+++ b/Pakettikauppa/Logistics/Model/Carrier/Pickuppoint.php
@@ -1,7 +1,9 @@
 <?php
 namespace Pakettikauppa\Logistics\Model\Carrier;
 
+use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Address\RateRequest;
+use Magento\Quote\Model\Quote\Item;
 
 class Pickuppoint extends \Magento\Shipping\Model\Carrier\AbstractCarrier implements
     \Magento\Shipping\Model\Carrier\CarrierInterface
@@ -55,7 +57,8 @@ class Pickuppoint extends \Magento\Shipping\Model\Carrier\AbstractCarrier implem
             $data = $this->registry->registry('pktkpicons');
             $this->registry->unregister('pktkpicons');
         }
-        $zip = $this->dataHelper->getZip();
+        $quote = $this->dataHelper->getQuoteSafely($request);
+        $zip = $quote->getShippingAddress()->getPostcode();
         $hasValidPickupPoints = false;
         if ($this->dataHelper->validateZip($zip) && $zip) {
             if (!empty($this->session->getData(static::API_RATE_LIMIT_CACHE_KEY))) {

--- a/Pakettikauppa/Logistics/Observer/OrderObserver.php
+++ b/Pakettikauppa/Logistics/Observer/OrderObserver.php
@@ -54,7 +54,7 @@ class OrderObserver implements ObserverInterface
                 $method_available = false;
 
                 if ($method == 'pktkppickuppoint') {
-                    $zip = $this->dataHelper->getZip() ?: $order->getShippingAddress()->getPostcode();
+                    $zip = !empty($this->dataHelper->getZip()) ? $this->dataHelper->getZip() : $order->getShippingAddress()->getPostcode();
                     $pickup_methods = $this->apiHelper->getPickuppoints($zip);
                     $pickuppoint_zip = $quote->getData('pickuppoint_zip');
 

--- a/Pakettikauppa/Logistics/Observer/OrderObserver.php
+++ b/Pakettikauppa/Logistics/Observer/OrderObserver.php
@@ -40,7 +40,9 @@ class OrderObserver implements ObserverInterface
             $quote = $this->cart->getQuote();
             $order = $observer->getOrder();
             $shipping_method_code = $quote->getShippingAddress()->getShippingMethod();
-
+            if (!$shipping_method_code) {
+                $shipping_method_code = $order->getShippingMethod();
+            }
             if (!$shipping_method_code) {
                 // For orders created via admin area
                 $shipping_method_code = $this->backendQuoteSession->getQuote()->getShippingAddress()->getShippingMethod();
@@ -52,7 +54,7 @@ class OrderObserver implements ObserverInterface
                 $method_available = false;
 
                 if ($method == 'pktkppickuppoint') {
-                    $zip = $this->dataHelper->getZip();
+                    $zip = $this->dataHelper->getZip() ?: $order->getShippingAddress()->getPostcode();
                     $pickup_methods = $this->apiHelper->getPickuppoints($zip);
                     $pickuppoint_zip = $quote->getData('pickuppoint_zip');
 

--- a/Pakettikauppa/Logistics/Plugin/Carrier/Image.php
+++ b/Pakettikauppa/Logistics/Plugin/Carrier/Image.php
@@ -47,22 +47,18 @@ class Image
 
         // MATCH METHOD AND IMAGE
         $images = $this->registry->registry('pktkpicons');
-        $method = $result->getCarrierTitle();
-        if(isset($images[$method])){
-          $url = $images[$method];
-        }else{
-          $url = '';
-        }
+        $method = $result->getMethodCode();
 
         // CREATE EXTENSION ATTRIBUTE
-        if($result->getExtensionAttributes()){
+        if ($result->getExtensionAttributes()){
           $extensibleAttribute = $result->getExtensionAttributes();
-        }else{
+        } else{
           $extensibleAttribute = $this->extensionFactory->create();
         }
 
+        $extensibleAttribute->setPostidistance($images[$method]['distance'] ?? '');
+        $extensibleAttribute->setPostidescription($images[$method]['description'] ?? '');
         // ATTACHE EXTENSION ATTIBUTE {image}
-        $extensibleAttribute->setImage($url);
         $result->setExtensionAttributes($extensibleAttribute);
         return $result;
     }

--- a/Pakettikauppa/Logistics/etc/extension_attributes.xml
+++ b/Pakettikauppa/Logistics/etc/extension_attributes.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
     <extension_attributes for="Magento\Quote\Api\Data\ShippingMethodInterface">
-        <attribute code="image" type="string" />
+        <attribute code="postidistance" type="string" />
+        <attribute code="postidescription" type="string" />
     </extension_attributes>
 </config>


### PR DESCRIPTION
Based on [this very old commit ](https://github.com/Pakettikauppa/magento1-pakettikauppa/commit/0c9846a514211ce7f4c3081aae67efb719b9d02b) it would seem the current validation performed to check if a delivery method is a home delivery method, is to check if there is an additional service with service_code 2106 (the pickup service code). However, it appears that some delivery methods, for example Posti Express (service code 2102) support both home delivery & pickup, and can therefore contain the additional service with code 2106.

Please see snippet from the `POST /shipping-methods/list` endpoint below:

```
   {
        "name": "Express-paketti",
        "shipping_method_code": 2102,
        "description": null,
        "service_provider": "Posti",
        "supported_countries": [
            "FI",
            "AX"
        ],
        "has_pickup_points": true,
        "home_delivery": true,
        "additional_services": [
            {
                "name": "Asiointikoodi",
                "service_code": "9902",
                "specifiers": null
            },
            {
                "name": "Henkilökohtaisesti luovutettava",
                "service_code": "3163",
                "specifiers": null
            },
            {
                "name": "Lauantaijakelu",
                "service_code": "3106",
                "specifiers": null
            },
            {
                "name": "LQ Lähetys",
                "service_code": "3143",
                "specifiers": null
            },
            {
                "name": "Luovuttaminen ilman vastaanottajan kuittaamista",
                "service_code": "3164",
                "specifiers": null
            },
            {
                "name": "Monipaketti lähetys",
                "service_code": "3102",
                "specifiers": [
                    {
                        "name": "count",
                        "type": "number"
                    }
                ]
            },
            {
                "name": "Noutopiste",
                "service_code": "2106",
                "specifiers": [
                    {
                        "name": "pickup_point_id",
                        "type": "number"
                    }
                ]
            },
            {
                "name": "Särkyvä",
                "service_code": "3104",
                "specifiers": null
            },
            {
                "name": "Soitto ennen jakelua",
                "service_code": "3166",
                "specifiers": null
            },
            {
                "name": "Suuri",
                "service_code": "3174",
                "specifiers": null
            }
        ],
        "icon": "https://static.pakettikauppa.fi/logos/posti/1.1_Posti_logo_Posti_Orange_rgb.png"
    }
```

The way it's implemented at the moment means the above delivery method will not show at checkout, as the methods properties are set to null and excluded from the result set.

These changes instead check the value of the `home_delivery` field on the method to determine if the method supports home delivery or not.

It would seem the additional_service with code 2106 was only recently added to service 2102, which is why this issue has not been spotted in the past, however I have no way of verifying this, so would be good if someone could confirm.